### PR TITLE
Allow filtering by search_format_types

### DIFF
--- a/explorer/document.py
+++ b/explorer/document.py
@@ -32,6 +32,7 @@ class Document(object):
         "specialist_sectors",
         "mainstream_browse_pages",
         "organisations",
+        "search_format_types",
         "format",
     )
 


### PR DESCRIPTION
This adds filtering by `search_format_types` in the explorer.

![screen shot 2015-06-17 at 14 04 19](https://cloud.githubusercontent.com/assets/233676/8207504/c6c1c01c-14f9-11e5-8270-683e062d0454.png)

Trello: https://trello.com/c/TEzydRhA/93-content-explorer-can-we-filter-by-searchable-format

**This should only be deployed after https://github.com/alphagov/rummager/pull/457 has been deployed.**
