### PR TITLE
Fix collections in CSV output

### DIFF
--- a/explorer/api.py
+++ b/explorer/api.py
@@ -71,7 +71,7 @@ def documents_csv(scope):
             (u', '.join(doc.mainstream_browse_pages)).encode('utf8'),
             (u', '.join(org['slug'] for org in doc.organisations)).encode('utf8'),
             (u', '.join(doc.policies)).encode('utf8'),
-            (u', '.join(doc.collections)).encode('utf8'),
+            (u', '.join(c['link'] for c in doc.document_collections)).encode('utf8'),
         ]
         writer.writerow(row)
     return Response(output.getvalue(), mimetype='text/csv')


### PR DESCRIPTION
In the CSV output, we were trying to return doc.collections, which is
the wrong name and never exists, so the column was always empty.

Instead, we need to return doc.document_collections, and extract just
the "link" value for each item in the list.  This provides the list of
links of collections that each document is in.
