### PR TITLE
Make it easier to filter on multiple field values

### DIFF
--- a/explorer/search.py
+++ b/explorer/search.py
@@ -47,7 +47,7 @@ def fetch_document_args(scope):
 def fetch_facet_args(scope, facet_field):
     args = scope.search_args()
     args["count"] = 0
-    args["facet_" + facet_field] = "1000,scope:all_filters"
+    args["facet_" + facet_field] = "1000,scope:exclude_field_filter"
     return args
 
 


### PR DESCRIPTION
Before this change, when you add a filter on, say, organisation, the
list of organisations is updated to only include those which are used in
the resulting documents.  This generally means that you get far fewer
options available.

Instead, change the list of values shown in each filter field to be
based on the current scope except for the filters applied to that field.
This allows multiple values to be chosen.  If multiple values are
chosen, documents are selected which match any of those values.
